### PR TITLE
Output correct link to docs on old version of clang

### DIFF
--- a/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
+++ b/sbt-scala-native/src/main/scala/scala/scalanative/sbtplugin/ScalaNativePluginInternal.scala
@@ -377,8 +377,8 @@ object ScalaNativePluginInternal {
     if (!clangIsRecentEnough) {
       throw new MessageOnlyException(
         s"No recent installation of clang found " +
-          s"at $pathToClangBinary.\nSee https://github.com/scala-native/scala-" +
-          s"native/blob/master/docs/building.md for details.")
+          s"at $pathToClangBinary.\nSee http://scala-native.readthedocs.io" + 
+          s"/en/latest/user/setup.html for details.")
     }
   }
 }


### PR DESCRIPTION
With an older version of clang, I get:

```
[error] No recent installation of clang found at /usr/bin/clang.
[error] See https://github.com/scala-native/scala-native/blob/master/docs/building.md for details.
```

That link gives me a 404; updated to the relevant readthedocs link.